### PR TITLE
Fix winsock2 is broken under Windows

### DIFF
--- a/src/common/opensslwrapper.cpp
+++ b/src/common/opensslwrapper.cpp
@@ -6,13 +6,12 @@
 
 #include "stdafx.h"
 #include "opensslwrapper.h"
-
+#include "winlite.h"
 //SDR_PUBLIC 	#include <openssl/bio.h>
 //SDR_PUBLIC 	#include <openssl/ssl.h>
 //SDR_PUBLIC 	#include <openssl/err.h>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
-#include "winlite.h"
 
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
`<winsock2>` should be included before `<windows.h>`, otherwise it breaks winsock2 functionality. `<openssl/rand.h>` already includes <windows.h> under Windows:
```h
# if defined(OPENSSL_SYS_WINDOWS)
#  include <windows.h>
# endif
```
MinGW is also not happy with this.