### PR TITLE
Allow building with a statically-compiled Protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,7 @@ set(MSVC_RUNTIME "dynamic")
 configure_msvc_runtime()
 print_default_msvc_flags()
 
+option(Protobuf_USE_STATIC_LIBS "Build with a static Protobuf library" OFF)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,8 +149,11 @@ macro(gamenetworkingsockets_common GNS_TARGET)
 			target_compile_definitions(${GNS_TARGET} PRIVATE
 				_CRT_SECURE_NO_WARNINGS
 				_ITERATOR_DEBUG_LEVEL=0
-				PROTOBUF_USE_DLLS
 			)
+			if(NOT Protobuf_USE_STATIC_LIBS)
+				target_compile_definitions(${GNS_TARGET} PRIVATE
+					PROTOBUF_USE_DLLS)
+			endif()
 			get_target_property(TARGET_TYPE ${GNS_TARGET} TYPE)
 			target_compile_options(${GNS_TARGET} PRIVATE
 				/EHs-c-   # Disable C++ exceptions


### PR DESCRIPTION
`Protobuf_USE_STATIC_LIBS` is an option specified in FindProtobuf.cmake
which, when enabled, will seek out a statically-compiled Protobuf.
`PROTOBUF_USE_DLLS` will need to be conditionally defined based on its
value, but FindProtobuf should do the rest.