### PR TITLE
Fix invalid offset increment after a 64 bit read.

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
@@ -452,7 +452,7 @@ bool CSteamNetworkConnectionBase::SNP_RecvDataChunk( int64 nPktNum, const void *
 		} while(false)
 
 	#define READ_64BITU( var, pszWhatFor ) \
-		do { EXPECT_BYTES(8,pszWhatFor); var = LittleQWord(*(uint64 *)pDecode); pDecode += 2; } while(false)
+		do { EXPECT_BYTES(8,pszWhatFor); var = LittleQWord(*(uint64 *)pDecode); pDecode += 8; } while(false)
 
 	#define READ_VARINT( var, pszWhatFor ) \
 		do { pDecode = DeserializeVarInt( pDecode, pEnd, var ); if ( !pDecode ) { DECODE_ERROR( "SNP data chunk decode overflow, varint for %s", pszWhatFor ); } } while(false)


### PR DESCRIPTION
As stated in the commit message, this looks like a typo for a very rare edge case that I assume nobody has hit (or if they have, couldn't easily reproduce). I couldn't see any reason why only skipping the first 2 bytes of the uint64 would be valid as there doesn't appear to be any crazy encoding schemes going on that could reuse the remaining bytes as part of the next frame too, and on top of that only have it apply to uint64s rather than the other sized types, but correct me if I'm wrong about that.