### PR TITLE
Pedantic C++11 fix

### DIFF
--- a/src/tier0/cpu.cpp
+++ b/src/tier0/cpu.cpp
@@ -281,7 +281,7 @@ bool Check3DNowTechnology(void)
      	if( !cpuid(0x80000001,unused,unused,unused,eax) )
 			return false;
 
-		return ( eax & 1<<31 ) != 0;
+		return ( eax & 1U<<31 ) != 0;
     }
     return false;
 #endif

--- a/src/tier1/netadr.cpp
+++ b/src/tier1/netadr.cpp
@@ -219,6 +219,7 @@ unsigned int netadr_t::GetHashKey( const netadr_t &netadr )
 	{
 		default:
 			result = std::hash<int>{}( netadr.type );
+			break;
 
 		case NA_IP:
 			result = std::hash<uint32>{}( netadr.ip );


### PR DESCRIPTION
Included is a very pedantic C++11 fix, which as well as being ignored by most compilers (since they jump over to the C++14 definition) is also only hit when checking for that incredibly modern and relevant 3DNow! technology :P
Also a non-C++11-specific fix where a switch-case looked to be falling through unintentionally, though again the other types appear to be deprecated making this a pedantic change too.