### PR TITLE
Use the correct macro to bswap a 32bit value

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
@@ -1237,7 +1237,7 @@ struct EncodedSegment
 
 			// Just always encode message number with 32 bits for now,
 			// to make sure we are hitting the worst case.  We can optimize this later
-			*(uint32*)pHdr = LittleWord( (uint32)pMsg->m_nMsgNum ); pHdr += 4;
+			*(uint32*)pHdr = LittleDWord( (uint32)pMsg->m_nMsgNum ); pHdr += 4;
 			m_hdr[0] |= 0x10;
 		}
 		else


### PR DESCRIPTION
I added a noop check to the bswap macros after spotting this and thankfully it didn't show up any other issues, however from the looks of things it should have been generating a compile error in `WordSwapC()` on the BE code path so I can only assume that that path hasn't been compiled for almost a year (last change to that line was c178029f029ad491cc7f8e699677ad3b30eca3cd, and I don't have any BE devices to test against).