### PR TITLE
Fixed StopSteamDatagramThread not releasing all sockets

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
@@ -1494,7 +1494,7 @@ static void StopSteamDatagramThread()
 			closesocket( s_hSockWakeThreadRead );
 			s_hSockWakeThreadRead = INVALID_SOCKET;
 		}
-		if ( s_hSockWakeThreadRead != INVALID_SOCKET )
+		if ( s_hSockWakeThreadWrite != INVALID_SOCKET )
 		{
 			closesocket( s_hSockWakeThreadWrite );
 			s_hSockWakeThreadWrite = INVALID_SOCKET;


### PR DESCRIPTION
Fixed a copy-paste bug in StopSteamDatagramThread, it would never release s_hSockWakeThreadWrite properly (was testing s_hSockWakeThreadRead)