### PR TITLE
Add link in readme to golang bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ to facilitate binding to other languages.
 Third party language bindings:
 
 * C#: <https://github.com/nxrighthere/ValveSockets-CSharp>
+* Go: <https://github.com/nielsAD/gns/>
 
 ## Roadmap
 


### PR DESCRIPTION
This PR adds a link to the golang bindings over at https://github.com/nielsAD/gns/