### PR TITLE
Fixed a minor build issue (protobuf msg ByteSize() is deprecated)

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_p2p.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_p2p.cpp
@@ -1239,7 +1239,7 @@ void CSteamNetworkConnectionP2P::QueueSignalReliableMessage( CMsgSteamNetworking
 	p->m_nID = ++m_nLastSendRendesvousMessageID;
 	p->m_usecRTO = 1;
 	p->m_msg = std::move( msg );
-	p->m_cbSerialized = p->m_msg.ByteSize();
+	p->m_cbSerialized = ProtoMsgByteSize(p->m_msg);
 	ScheduleSendSignal( pszDebug );
 }
 


### PR DESCRIPTION
Fixes what was breaking the [Travis CI builds](https://travis-ci.org/github/ValveSoftware/GameNetworkingSockets/builds/689400918)