### PR TITLE
CMake installation & vcpkg support

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,6 +12,7 @@ Building
   * OpenSSL 1.1.1 or later
   * OpenSSL 1.1.x, plus ed25519-donna and curve25519-donna.  (We've made some
     minor changes, so the source is included in this project.)
+  * libsodium
   * [bcrypt](https://docs.microsoft.com/en-us/windows/desktop/api/bcrypt/) (windows only)
 * Google protobuf 2.6.1+
 
@@ -55,10 +56,28 @@ $ ninja
 
 ## Windows / Visual Studio
 
-Unfortuanetly, because Windows lacks a robust package ecosystem, getting setup
-is a bit of an arduous gauntlet.
+On Windows, you can use the [vcpkg](https://github.com/microsoft/vcpkg/) package manager. Or setup the 
+dependencies by hand, which is a bit of an arduous gauntlet.
 
-### OpenSSL
+### vcpkg
+
+Follow the [quick start](https://github.com/microsoft/vcpkg/#quick-start-windows) instructions to set up vcpkg, 
+and to integrate it with Visual Studio.
+
+To build GameNetworking sockets:
+
+```
+> .\vcpkg\vcpkg --overlay-ports=path\to\GameNetworkingSockets\vcpkg_ports install gamenetworkingsockets
+```
+You can use the vcpkg option `--triplet x64-windows` or `--triplet x86-windows` to force the choice of a 
+particular target architecture. The library should be immediately available in Visual Studio projects if 
+the vcpkg integration is installed, or the vcpkg CMake toolchain file can be used for CMake-based projects. 
+
+To use libsodium as the crypto backend rather than OpenSSL, install `gamenetworkingsockets[core,libsodium]`.
+
+### Manual setup
+
+#### OpenSSL
 
 You can install the [OpenSSL binaries](https://slproweb.com/products/Win32OpenSSL.html)
 provided by Shining Light Productions. The Windows CMake distribution understands
@@ -69,7 +88,7 @@ easier. Be sure to pick the installers **without** the "Light"suffix. In this in
 For CMake to find the libraries, you may need to set the environment variable
 `OPENSSL_ROOT_DIR`.
 
-### Checking prerequisites
+#### Checking prerequisites
 
 Start a Visual Studio Command Prompt (2017+), and double-check
 that you have everything you need.  Note that Visual Studio comes with these tools,
@@ -99,7 +118,7 @@ C:\dev> ninja --version
 ```
 
 
-### Protobuf
+#### Protobuf
 
 Instructions for getting a working installation of google protobuf on Windows can
 be found [here](https://github.com/protocolbuffers/protobuf/blob/master/cmake/README.md).
@@ -138,7 +157,7 @@ C:\dev\protobuf\cmake_build> ninja
 C:\dev\protobuf\cmake_build> ninja install
 ```
 
-### Building
+#### Building
 
 Start a Visual Studio Command Prompt, and create a directory to hold the build output.
 

--- a/cmake/GameNetworkingSocketsConfig.cmake.in
+++ b/cmake/GameNetworkingSocketsConfig.cmake.in
@@ -1,0 +1,25 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+if(@USE_CRYPTO@ STREQUAL "OpenSSL" OR @USE_CRYPTO25519@ STREQUAL "OpenSSL")
+    find_dependency(OpenSSL)
+endif()
+
+if(@USE_CRYPTO@ STREQUAL "libsodium" OR @USE_CRYPTO25519@ STREQUAL "libsodium")
+    find_dependency(sodium)
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/GameNetworkingSockets.cmake)
+
+set_target_properties(
+    GameNetworkingSockets::GameNetworkingSockets GameNetworkingSockets::GameNetworkingSockets_s
+    PROPERTIES IMPORTED_GLOBAL True
+)
+add_library(GameNetworkingSockets::shared ALIAS GameNetworkingSockets::GameNetworkingSockets)
+add_library(GameNetworkingSockets::static ALIAS GameNetworkingSockets::GameNetworkingSockets_s)
+
+check_required_components(GameNetworkingSockets)
+set(GameNetworkingSockets_FOUND 1)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+project(gns_example C CXX)
+
 add_executable(
 	example_chat
 	example_chat.cpp)
-target_link_libraries(example_chat GameNetworkingSockets)
-add_sanitizers(example_chat)
+
+# If building the example as a standalone project, need to find GameNetworkingSockets
+if(${CMAKE_PROJECT_NAME} STREQUAL "gns_example")
+	find_package(GameNetworkingSockets CONFIG REQUIRED)
+endif()
+
+target_link_libraries(example_chat GameNetworkingSockets::GameNetworkingSockets)
+
+if(COMMAND add_sanitizers)
+	add_sanitizers(example_chat)
+endif()
 
 # vim: set ts=4 sts=4 sw=4 noet:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckSymbolExists)
 include(CMakePushCheckState)
+include(GNUInstallDirs)
 
 find_package(Protobuf REQUIRED)
 find_package(Threads REQUIRED)
@@ -146,13 +147,14 @@ macro(gamenetworkingsockets_common GNS_TARGET)
 	target_sources(${GNS_TARGET} PRIVATE ${GNS_PROTO_SRCS})
 
 	target_include_directories(${GNS_TARGET} PUBLIC
-		"../include"
-		${CMAKE_CURRENT_BINARY_DIR}
+		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+		"$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/GameNetworkingSockets>"
 	)
 
 	target_include_directories(${GNS_TARGET} PRIVATE
 		"common"
 		"public"
+		${CMAKE_CURRENT_BINARY_DIR}
 
 		# Only necessary if we're not using protobuf::libprotobuf
 		# But that's not supported until CMake 3.9
@@ -266,19 +268,48 @@ macro(gamenetworkingsockets_common GNS_TARGET)
 
 	set_target_properties(${GNS_TARGET} PROPERTIES
 		CXX_STANDARD 11
-		)
+	)
+
+	add_sanitizers(${GNS_TARGET})
 
 endmacro()
 
 add_library(GameNetworkingSockets SHARED "")
+add_library(GameNetworkingSockets::GameNetworkingSockets ALIAS GameNetworkingSockets)
 add_library(GameNetworkingSockets::shared ALIAS GameNetworkingSockets)
 gamenetworkingsockets_common(GameNetworkingSockets)
-add_sanitizers(GameNetworkingSockets)
 
 add_library(GameNetworkingSockets_s STATIC "")
+add_library(GameNetworkingSockets::GameNetworkingSockets_s ALIAS GameNetworkingSockets_s)
 add_library(GameNetworkingSockets::static ALIAS GameNetworkingSockets_s)
 target_compile_definitions(GameNetworkingSockets_s INTERFACE STEAMNETWORKINGSOCKETS_STATIC_LINK)
 gamenetworkingsockets_common(GameNetworkingSockets_s)
-add_sanitizers(GameNetworkingSockets_s)
+
+# Install rules
+install(
+	TARGETS GameNetworkingSockets GameNetworkingSockets_s
+	EXPORT GameNetworkingSockets
+)
+
+install(DIRECTORY ../include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GameNetworkingSockets)
+
+install(
+	EXPORT GameNetworkingSockets
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+	NAMESPACE GameNetworkingSockets::
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(../cmake/GameNetworkingSocketsConfig.cmake.in
+	${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+	PATH_VARS CMAKE_INSTALL_FULL_INCLUDEDIR
+)
+
+install(FILES 
+	${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+)
 
 # vim: set ts=4 sts=4 sw=4 noet:

--- a/vcpkg_ports/gamenetworkingsockets/CONTROL
+++ b/vcpkg_ports/gamenetworkingsockets/CONTROL
@@ -1,0 +1,14 @@
+Source: gamenetworkingsockets
+Version: 2020-07-10
+Description: GameNetworkingSockets is a basic transport layer for games.
+Homepage: https://github.com/ValveSoftware/GameNetworkingSockets
+Build-Depends: protobuf
+Default-Features: openssl
+
+Feature: openssl
+Description: Use OpenSSL as the crypto backend
+Build-Depends: openssl
+
+Feature: libsodium
+Description: Use libsodium as the crypto backend
+Build-Depends: libsodium

--- a/vcpkg_ports/gamenetworkingsockets/portfile.cmake
+++ b/vcpkg_ports/gamenetworkingsockets/portfile.cmake
@@ -1,0 +1,30 @@
+set(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+if(openssl IN_LIST FEATURES)
+    set(CRYPTO_BACKEND OpenSSL)
+endif()
+
+if(libsodium IN_LIST FEATURES)
+    set(CRYPTO_BACKEND libsodium)
+endif()
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+    -DGAMENETWORKINGSOCKETS_BUILD_TESTS=OFF
+    -DGAMENETWORKINGSOCKETS_BUILD_EXAMPLES=OFF
+    -DUSE_CRYPTO=${CRYPTO_BACKEND}
+    -DUSE_CRYPTO25519=${CRYPTO_BACKEND}
+)
+
+vcpkg_install_cmake()
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/GameNetworkingSockets" TARGET_PATH "share/GameNetworkingSockets")
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+
+vcpkg_copy_pdbs()


### PR DESCRIPTION
Adds support for a CMake install target which installs the library to the system. Once installed, it can then be used with `find_package(GameNetworkingSockets CONFIG)`

The chat example's CMakeLists.txt has been modified so that it can be built standalone, referring to the system-installed copy of GameNetworkingSockets.

This CMake install target is used as the basis for a vcpkg port definition. This makes using the library in Windows significantly easier as it deals with getting the dependencies. Ideally, the plan is to upstream this port definition into the vcpkg project.

I believe that this fixes: https://github.com/ValveSoftware/GameNetworkingSockets/issues/114