### PR TITLE
CMake install tweaks

### DIFF
--- a/cmake/GameNetworkingSocketsConfig.cmake.in
+++ b/cmake/GameNetworkingSocketsConfig.cmake.in
@@ -18,8 +18,11 @@ set_target_properties(
     GameNetworkingSockets::GameNetworkingSockets GameNetworkingSockets::GameNetworkingSockets_s
     PROPERTIES IMPORTED_GLOBAL True
 )
-add_library(GameNetworkingSockets::shared ALIAS GameNetworkingSockets::GameNetworkingSockets)
-add_library(GameNetworkingSockets::static ALIAS GameNetworkingSockets::GameNetworkingSockets_s)
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.11.0")
+    add_library(GameNetworkingSockets::shared ALIAS GameNetworkingSockets::GameNetworkingSockets)
+    add_library(GameNetworkingSockets::static ALIAS GameNetworkingSockets::GameNetworkingSockets_s)
+endif()
 
 check_required_components(GameNetworkingSockets)
 set(GameNetworkingSockets_FOUND 1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -289,8 +289,9 @@ gamenetworkingsockets_common(GameNetworkingSockets_s)
 install(
 	TARGETS GameNetworkingSockets GameNetworkingSockets_s
 	EXPORT GameNetworkingSockets
-	LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(DIRECTORY ../include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GameNetworkingSockets)


### PR DESCRIPTION
Tweaked the install destinations so that things definitely appear in the right place (tested on Ubuntu Bionic and Windows/vcpkg). This makes sure that .a and .so appear in /usr/local/lib on Ubuntu Bionic, and .lib in /lib and .dll in /bin for vcpkg, which should fix #131 

Also made creation of the `GameNetworkingSockets::shared` and `GameNetworkingSockets::static` aliases conditional on CMake version >= 3.11, which is when the behaviour of `add_library()` changed to make this legal. 