### PR TITLE
Fixes for WebRTC / vcpkg build

### DIFF
--- a/cmake/GameNetworkingSocketsConfig.cmake.in
+++ b/cmake/GameNetworkingSocketsConfig.cmake.in
@@ -12,6 +12,10 @@ if(@USE_CRYPTO@ STREQUAL "libsodium" OR @USE_CRYPTO25519@ STREQUAL "libsodium")
     find_dependency(sodium)
 endif()
 
+if(@STEAMWEBRTC_ABSL_SOURCE@ STREQUAL "package")
+    find_dependency(absl REQUIRED)
+endif()
+
 include(${CMAKE_CURRENT_LIST_DIR}/GameNetworkingSockets.cmake)
 
 set_target_properties(

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.9)
 project(gns_example C CXX)
 
 #
@@ -33,7 +34,9 @@ add_executable(
 	example_chat
 	example_chat.cpp)
 
-set_target_common_gns_properties( example_chat )
+if(COMMAND set_target_common_gns_properties)
+	set_target_common_gns_properties( example_chat )
+endif()
 
 # If building the example as a standalone project, need to find GameNetworkingSockets
 if(${CMAKE_PROJECT_NAME} STREQUAL "gns_example")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,15 +290,17 @@ add_library(GameNetworkingSockets::static ALIAS GameNetworkingSockets_s)
 target_compile_definitions(GameNetworkingSockets_s INTERFACE STEAMNETWORKINGSOCKETS_STATIC_LINK)
 gamenetworkingsockets_common(GameNetworkingSockets_s)
 
-# HELP Should not need this if() here
-#CMake Error: install(EXPORT "GameNetworkingSockets" ...) includes target "GameNetworkingSockets" which requires target "steamwebrtc" that is not in the export set.
-#CMake Error: install(EXPORT "GameNetworkingSockets" ...) includes target "GameNetworkingSockets_s" which requires target "steamwebrtc" that is not in the export set.
-if( NOT USE_STEAMWEBRTC ) # HALP
-
-
 # Install rules
+
+if(USE_STEAMWEBRTC)
+	set(CONDITIONAL_WEBRTC_TARGET steamwebrtc webrtc-lite)
+endif()
+
 install(
-	TARGETS GameNetworkingSockets GameNetworkingSockets_s
+	TARGETS 
+		GameNetworkingSockets
+		GameNetworkingSockets_s
+		${CONDITIONAL_WEBRTC_TARGET}
 	EXPORT GameNetworkingSockets
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -307,25 +309,26 @@ install(
 
 install(DIRECTORY ../include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GameNetworkingSockets)
 
-install(
-	EXPORT GameNetworkingSockets
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
-	NAMESPACE GameNetworkingSockets::
-	)
+# Export doesn't work if we're using WebRTC and the Abseil dependency came from the submodule
+if(NOT (USE_STEAMWEBRTC AND STEAMWEBRTC_ABSL_SOURCE STREQUAL submodule))
+	install(
+		EXPORT GameNetworkingSockets
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+		NAMESPACE GameNetworkingSockets::
+		)
 
-include(CMakePackageConfigHelpers)
+	include(CMakePackageConfigHelpers)
 
-configure_package_config_file(../cmake/GameNetworkingSocketsConfig.cmake.in
-	${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
-	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
-	PATH_VARS CMAKE_INSTALL_FULL_INCLUDEDIR
-	)
+	configure_package_config_file(../cmake/GameNetworkingSocketsConfig.cmake.in
+		${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
+		INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+		PATH_VARS CMAKE_INSTALL_FULL_INCLUDEDIR
+		)
 
-install(FILES 
-	${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
-	)
-
-endif() # END HALP
+	install(FILES 
+		${CMAKE_CURRENT_BINARY_DIR}/GameNetworkingSocketsConfig.cmake
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GameNetworkingSockets
+		)
+endif()
 
 # vim: set ts=4 sts=4 sw=4 noet:

--- a/src/external/steamwebrtc/CMakeLists.txt
+++ b/src/external/steamwebrtc/CMakeLists.txt
@@ -7,13 +7,21 @@ find_package(Protobuf REQUIRED)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(abseil_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../abseil)
-if(NOT EXISTS ${abseil_SOURCE_DIR}/CMakeLists.txt)
-	message(FATAL_ERROR "abeil submodule not initialized.\n(Try 'git submodule update src/external/abseil')" )
-endif()
-add_subdirectory(${abseil_SOURCE_DIR} ${CMAKE_BINARY_DIR}/abseil EXCLUDE_FROM_ALL)
-if(LTO)
-	set_property(DIRECTORY ${abseil_SOURCE_DIR} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+find_package(absl QUIET)
+
+if(NOT absl_FOUND)
+	set(STEAMWEBRTC_ABSL_SOURCE submodule PARENT_SCOPE)
+
+	set(abseil_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../abseil)
+	if(NOT EXISTS ${abseil_SOURCE_DIR}/CMakeLists.txt)
+		message(FATAL_ERROR "abeil submodule not initialized.\n(Try 'git submodule update src/external/abseil')" )
+	endif()
+	add_subdirectory(${abseil_SOURCE_DIR} ${CMAKE_BINARY_DIR}/abseil EXCLUDE_FROM_ALL)
+	if(LTO)
+		set_property(DIRECTORY ${abseil_SOURCE_DIR} PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+	endif()
+else()
+	set(STEAMWEBRTC_ABSL_SOURCE package PARENT_SCOPE)
 endif()
 
 set(webrtc_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../webrtc)
@@ -710,69 +718,17 @@ endfunction( compile_webrtc_proto )
 #    ${CONAN_ABSEIL_ROOT}/lib
 #)
 
-target_include_directories(webrtc-lite PUBLIC
+target_include_directories(webrtc-lite PRIVATE
 	${webrtc_SOURCE_DIR}
 	#${webrtc_BUILD_DIR}  # ???
 	${CMAKE_CURRENT_BINARY_DIR}/..
 	${CMAKE_CURRENT_BINARY_DIR}
 	)
 
-set(ABSEIL_DEPENDENCIES
-	absl_time_zone
-	absl_time
-	absl_throw_delegate
-	absl_synchronization
-	absl_symbolize
-	absl_strings_internal
-	absl_strings
-	absl_str_format_internal
-	absl_status
-	absl_stacktrace
-	absl_spinlock_wait
-	absl_scoped_set_env
-	absl_raw_logging_internal
-	absl_raw_hash_set
-	absl_random_seed_sequences
-	absl_random_seed_gen_exception
-	absl_random_internal_seed_material
-	absl_random_internal_randen_slow
-	absl_random_internal_randen_hwaes_impl
-	absl_random_internal_randen_hwaes
-	absl_random_internal_randen
-	absl_random_internal_pool_urbg
-	absl_random_internal_distribution_test_util
-	absl_random_distributions
-	absl_periodic_sampler
-	absl_malloc_internal
-	absl_log_severity
-	absl_leak_check_disable
-	absl_leak_check
-	absl_int128
-	absl_hashtablez_sampler
-	absl_hash
-	absl_graphcycles_internal
-	absl_flags_usage_internal
-	absl_flags_usage
-	absl_flags_registry
-	absl_flags_program_name
-	absl_flags_parse
-	absl_flags_marshalling
-	absl_flags_internal
-	absl_flags_config
-	absl_flags
-	absl_failure_signal_handler
-	absl_exponential_biased
-	absl_examine_stack
-	absl_dynamic_annotations
-	absl_demangle_internal
-	absl_debugging_internal
-	absl_cord
-	absl_civil_time
-	absl_city
-	absl_base
-	absl_bad_variant_access
-	absl_bad_optional_access
-	absl_bad_any_cast_impl
+set(ABSEIL_DEPENDENCIES 
+	absl::meta
+	absl::optional
+	absl::strings
 	)
 
 if(LTO)
@@ -795,14 +751,15 @@ set_target_properties(webrtc-lite PROPERTIES
 
 set_property(TARGET webrtc-lite PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-include_directories(
-	${webrtc_SOURCE_DIR}/include/webrtc
-	)
-
 add_library(steamwebrtc STATIC
 	"ice_session.h"
 	"steamwebrtc_internal.h"
 	"ice_session.cpp"
+	)
+
+target_include_directories(steamwebrtc PRIVATE
+	${webrtc_SOURCE_DIR}/include/webrtc
+	${webrtc_SOURCE_DIR}
 	)
 
 set_target_common_gns_properties(steamwebrtc)

--- a/vcpkg_ports/gamenetworkingsockets/CONTROL
+++ b/vcpkg_ports/gamenetworkingsockets/CONTROL
@@ -1,5 +1,5 @@
 Source: gamenetworkingsockets
-Version: 2020-07-10
+Version: 2020-10-06
 Description: GameNetworkingSockets is a basic transport layer for games.
 Homepage: https://github.com/ValveSoftware/GameNetworkingSockets
 Build-Depends: protobuf
@@ -12,3 +12,7 @@ Build-Depends: openssl
 Feature: libsodium
 Description: Use libsodium as the crypto backend
 Build-Depends: libsodium
+
+Feature: webrtc
+Description: Compiles WebRTC support for P2P
+Build-Depends: abseil

--- a/vcpkg_ports/gamenetworkingsockets/portfile.cmake
+++ b/vcpkg_ports/gamenetworkingsockets/portfile.cmake
@@ -8,6 +8,12 @@ if(libsodium IN_LIST FEATURES)
     set(CRYPTO_BACKEND libsodium)
 endif()
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+      webrtc USE_STEAMWEBRTC
+)
+
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
     PREFER_NINJA
@@ -16,6 +22,7 @@ vcpkg_configure_cmake(
     -DGAMENETWORKINGSOCKETS_BUILD_EXAMPLES=OFF
     -DUSE_CRYPTO=${CRYPTO_BACKEND}
     -DUSE_CRYPTO25519=${CRYPTO_BACKEND}
+    ${FEATURE_OPTIONS}
 )
 
 vcpkg_install_cmake()


### PR DESCRIPTION
* Fixed installation with WebRTC is enabled
* Added vcpkg feature option for webrtc
* Try to detect abseil before using our own submodule copy (means we can use the one from vcpkg)
* Fixed standalone example build
* Shaved down abseil dependencies and use properly namespaced names