### PR TITLE
Fix the compilation of the signaling example for OSX

### DIFF
--- a/examples/trivial_signaling_client.cpp
+++ b/examples/trivial_signaling_client.cpp
@@ -14,6 +14,11 @@
 #include <steam/isteamnetworkingutils.h>
 #include <steam/steamnetworkingcustomsignaling.h>
 
+#ifndef SOCK_NONBLOCK
+#include <fcntl.h>
+# define SOCK_NONBLOCK O_NONBLOCK
+#endif
+
 #ifdef POSIX
 	#include <unistd.h>
 	#include <sys/socket.h>


### PR DESCRIPTION
OSX does not know "SOCK_NONBLOCK"