### PR TITLE
Fix build on not specified 64-bit architectures

### DIFF
--- a/include/steam/steamtypes.h
+++ b/include/steam/steamtypes.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2008, Valve LLC, All rights reserved. ============
+//========= Copyright Â© 1996-2008, Valve LLC, All rights reserved. ============
 //
 // Purpose:
 //
@@ -24,7 +24,7 @@ typedef unsigned char uint8;
 	#define POSIX 1
 #endif
 
-#if defined(__x86_64__) || defined(_WIN64) || defined(__aarch64__) || defined(__s390x__)
+#if defined(__LP64__) || defined(_WIN64)
 #define X64BITS
 #endif
 


### PR DESCRIPTION
Only x86_64, aarch64 and s390x are specified as 64-bit, but there are more 64-bit architectures, e.g.:
- mips64,
- powerpc64,
- powerpc64le,
- riscv64.

Those are not on the list. Of those, I checked that GameNetworkingSockets builds fine on powerpc64le with this change.