### PR TITLE
Fixed initial connection userdata loading

### DIFF
--- a/src/steamnetworkingsockets/clientlib/csteamnetworkingsockets.cpp
+++ b/src/steamnetworkingsockets/clientlib/csteamnetworkingsockets.cpp
@@ -1955,7 +1955,7 @@ bool CSteamNetworkingUtils::SetConfigValue( ESteamNetworkingConfigValue eValue,
 				return false;
 
 			// Set the data, possibly fixing up existing queued messages, etc
-			pConn->SetUserData( pConn->m_connectionConfig.m_ConnectionUserData.m_data );
+			pConn->SetUserData( newData );
 			return true;
 		}
 


### PR DESCRIPTION
Currently if developer try to specify user data for local connection before `HSteamNetConnection` creation with help of `SteamNetworkingConfigValue_t` list, user data will not be set to expected value.

For example:
```
    constexpr int numConnectionConfigEntriesCount = 2;
    std::array< SteamNetworkingConfigValue_t, numConnectionConfigEntriesCount > connectionConfig;

    connectionConfig[ 0 ].SetPtr( k_ESteamNetworkingConfig_Callback_ConnectionStatusChanged, callback );
    connectionConfig[ 1 ].SetInt64( k_ESteamNetworkingConfig_ConnectionUserData, 123 );

    HSteamNetConnection connectionHandle = sockets->ConnectByIPAddress( address, numConnectionConfigEntriesCount, connectionConfig.data() );
```

This will lead to weird behaviour, when callback is called user data will be equal to `0`, however it is expected to be `123`

Hopefully this would allow developers to use scenarios described in #162 