### PR TITLE
[CMake] Explicitly specify CXX_EXTENSIONS ON

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -227,6 +227,10 @@ macro(set_clientlib_target_properties GNS_TARGET)
 
 	set_target_common_gns_properties( ${GNS_TARGET} )
 
+	set_target_properties(${GNS_TARGET} PROPERTIES
+		CXX_EXTENSIONS ON
+	)
+
 	target_include_directories(${GNS_TARGET} PUBLIC
 		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
 		"$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/GameNetworkingSockets>"


### PR DESCRIPTION
When using GameNetworkingSockets via CMake's `add_subdirectory`, the parent project may set `CXX_EXTENSIONS` to `OFF` (in a way that may be inherited by GameNetworkingSockets).

However, it seems that GameNetworkingSockets currently requires `CXX_EXTENSIONS` to be `ON`.

(The use of `,## __VA_ARGS__` in `src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.h`, as one example.)

This PR explicitly sets `CXX_EXTENSIONS` to `ON` for the GNS clientlib targets.