### PR TITLE
Update checkout action to use main branch instead of master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       IMAGE: ubuntu
       IMAGE_TAG: latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       # Note only alpine needs "preinstall" step
       - name: Update packages
         run: sudo -E bash .github/update-packages.sh
@@ -30,7 +30,7 @@ jobs:
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
 
       - uses: lukka/get-cmake@latest
 
@@ -107,7 +107,7 @@ jobs:
             docker_image: alpine
             docker_tag: latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: Launch container
         run: |
           docker run -d --rm --name github-docker-builder -e LC_ALL="C" -e LANG="C" -v ${{ github.workspace }}:/build -w /build ${{ matrix.docker_image }}:${{ matrix.docker_tag }} tail -f /dev/null


### PR DESCRIPTION
The checkout action's `master` branch was renamed to `main`. According to [this Github blog post](https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/) you'll be prompted to rename it when editing the workflow on the Github website, so i've changed the name to match the new one to avoid any problems in the future.