### PR TITLE
Mark all directories as safe so CI builds don't fail with "unsafe repository" errors

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -57,6 +57,10 @@ has_clang || has_gcc || die "No compiler available"
 export CCACHE_DIR=$PWD/build-ci-ccache
 ccache -M4G
 
+# Mark all directories as safe so checkouts performed in CMakeLists.txt don't cause "unsafe repository" errors.
+# See https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory '*'
+
 # Use shallow clones of submodules for space/time efficiency.
 #git submodule update --init --depth=1 2>&1 | cat
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,11 @@ jobs:
           cd build
           cmake -S .. -G Ninja -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_TOOLS=ON
 
+      # Mark all directories as safe so checkouts performed in CMakeLists.txt don't cause "unsafe repository" errors.
+      # See https://github.com/actions/checkout/issues/766
+      - name: Configure Git
+        run: git config --global --add safe.directory '*'
+
       - name: Build projects
         working-directory: '${{ github.workspace }}/build'
         run: ninja


### PR DESCRIPTION
A recent change in Git broke the CI build. When a Git submodule is checked out on-demand in CMake config files the build fails with this error:
```sh
fatal: unsafe repository ('/build' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /build
```

The change in question is a security fix for CVE-2022-24765.

See this commit for more information about the change that caused this: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9

See this issue for more information on how it is recommended to be fixed for specific directories: https://github.com/actions/checkout/issues/766

See this blog post for more information about the vulnerability: https://github.blog/2022-04-12-git-security-vulnerability-announced/

This PR uses `git config --global --add safe.directory '*'` to disable the new security check in order to restore the original behavior. This depends on special behavior used when the directory is `*`. See the Git documentation for how this works: https://git-scm.com/docs/git-config/2.35.3#Documentation/git-config.txt-safedirectory

Since CI builds should only include Git configurations provided by the repository and Docker images this shouldn't cause any security issues.

An alternative solution is to check out the repository and all submodules during the checkout action, but this increases the amount of time required to perform checkout. Since submodules are checked out on-demand in certain CMake config files this is probably not the desired solution.

Using the solution recommended in the error message (adding `/build`) does not work because one of the Unix flavors runs will still fail, reporting `/build/src/external/steamwebrtc/../abseil` instead of `/build` as the unsafe repository.

To avoid problems in the future i've also added this for Windows builds.