### PR TITLE
Fix incorrect nonempty check in ICE initialization

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_p2p_ice.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_p2p_ice.cpp
@@ -189,7 +189,7 @@ void CSteamNetworkConnectionP2P::CheckInitICE()
 			V_AllocAndSplitString( m_connectionConfig.m_P2P_TURN_PassList.Get().c_str(), ",", vecTurnPasses, true );
 
 			// If turn arrays lengths (servers, users and passes) are not match, treat all TURN servers as unauthenticated
-			if ( !vecTurnUsers.IsEmpty() > 0 || !vecTurnPasses.IsEmpty() )
+			if ( !vecTurnUsers.IsEmpty() || !vecTurnPasses.IsEmpty() )
 			{
 				if ( cfg.m_nTurnServers != vecTurnUsers.Count() || cfg.m_nTurnServers != vecTurnPasses.Count() )
 				{


### PR DESCRIPTION
Presumably this code originally used `vecTurnUsers.Count() > 0`.

`!vecTurnUsers.IsEmpty() > 0` should always be equivalent to `!vecTurnUsers.IsEmpty()` so this wasn't a bug.