### PR TITLE
Add missing override specifier

### DIFF
--- a/examples/trivial_signaling_client.cpp
+++ b/examples/trivial_signaling_client.cpp
@@ -373,7 +373,7 @@ next_message:
 		}
 	}
 
-	virtual void Release()
+	virtual void Release() override
 	{
 		// NOTE: Here we are assuming that the calling code has already cleaned
 		// up all the connections, to keep the example simple.


### PR DESCRIPTION
This silences a compiler warning (printed 7 times out of 13 warnings total in the Ubuntu CI build) when compiling with `-Winconsistent-missing-override`.