### PR TITLE
Add find_dependency(Protobuf)

### DIFF
--- a/cmake/GameNetworkingSocketsConfig.cmake.in
+++ b/cmake/GameNetworkingSocketsConfig.cmake.in
@@ -3,6 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(Threads)
+find_dependency(Protobuf)
 
 if(@USE_CRYPTO@ STREQUAL "OpenSSL")
     find_dependency(OpenSSL)


### PR DESCRIPTION
Fix link error: 
```
  The link interface of target "GameNetworkingSockets::GameNetworkingSockets"
  contains:

    protobuf::libprotobuf

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```