### PR TITLE
Improve Linux platform's debugger check

### DIFF
--- a/src/tier0/dbg.cpp
+++ b/src/tier0/dbg.cpp
@@ -59,20 +59,18 @@ bool Plat_IsInDebugSession()
 	return ((info.kp_proc.p_flag & P_TRACED) == P_TRACED);
 #elif IsLinux()
 	static FILE *fp;
-	if ( !fp )
-	{
-		char rgchProcStatusFile[256]; rgchProcStatusFile[0] = '\0';
-		snprintf( rgchProcStatusFile, sizeof(rgchProcStatusFile), "/proc/%d/status", getpid() );
-		fp = fopen( rgchProcStatusFile, "r" );
-	}
-
-	char rgchLine[256]; rgchLine[0] = '\0';
+	char rgchProcStatusFile[256] = { '\0' };
+	char rgchLine[256] = { '\0' };
 	int nTracePid = 0;
+
+	snprintf( rgchProcStatusFile, sizeof(rgchProcStatusFile), "/proc/%d/status", getpid() );
+	fp = fopen( rgchProcStatusFile, "r" );
+
 	if ( fp )
 	{
 		const char *pszSearchString = "TracerPid:";
 		const uint cchSearchString = strlen( pszSearchString );
-		rewind( fp );
+
 		while ( fgets( rgchLine, sizeof(rgchLine), fp ) )
 		{
 			if ( !strncasecmp( pszSearchString, rgchLine, cchSearchString ) )

--- a/src/tier0/dbg.cpp
+++ b/src/tier0/dbg.cpp
@@ -81,6 +81,7 @@ bool Plat_IsInDebugSession()
 			}
 		}
 	}
+	fclose(fp);
 	return (nTracePid != 0);
 #elif IsPlaystation()
 	// NDA material


### PR DESCRIPTION
`FILE` pointer first checks it's availability but it's not necessary until an operation being done (e.g. opening a file stream, closing, writing etc.).
Rewinding is useless as buffer position is constant and `fgets` will read each line individually. 

Edit: Also, closing the file stream when `fgets` done its job.