### PR TITLE
add tests for older windows versions and fix bcrypt detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,13 @@ jobs:
 
   build-and-test-windows:
     #if: false  # Temporarily disable
-    name: Build And Test Windows
-    runs-on: windows-latest
+    name: Build And Test Windows ${{ matrix.os-version }} ${{ matrix.crypto }}
+    runs-on: windows-${{ matrix.os-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version: [2019, 2022]
+        crypto: [OpenSSL, BCrypt]
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
     steps:
@@ -63,7 +68,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -S .. -G Ninja -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake
+          cmake -S .. -G Ninja -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE=${{env.VCPKG_ROOT}}/scripts/buildsystems/vcpkg.cmake -DUSE_CRYPTO=${{matrix.crypto}}
         shell: cmd
 
       # Mark all directories as safe so checkouts performed in CMakeLists.txt don't cause "unsafe repository" errors.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,15 +84,17 @@ if (WIN32)
 	string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 	string(REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
-	#
-	# Check whether BCrypt can be used with this SDK version
-	#
-	cmake_push_check_state()
-		set(CMAKE_REQUIRED_LIBRARIES bcrypt)
-		check_symbol_exists(BCryptEncrypt windows.h BCRYPT_AVAILABLE)
-	cmake_pop_check_state()
-	if (NOT BCRYPT_AVAILABLE AND USE_CRYPTO STREQUAL "BCrypt")
-		message(FATAL_ERROR "You're on Windows but BCrypt seems to be unavailable, you will need OpenSSL")
+	if (USE_CRYPTO STREQUAL "BCrypt")
+		#
+		# Check whether BCrypt can be used with this SDK version
+		#
+		cmake_push_check_state()
+			set(CMAKE_REQUIRED_LIBRARIES bcrypt)
+			check_symbol_exists(BCryptEncrypt windows.h BCRYPT_AVAILABLE)
+		cmake_pop_check_state()
+		if (NOT BCRYPT_AVAILABLE)
+			message(FATAL_ERROR "You're on Windows but BCrypt seems to be unavailable, you will need OpenSSL")
+		endif()
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,11 +88,9 @@ if (WIN32)
 		#
 		# Check whether BCrypt can be used with this SDK version
 		#
-		cmake_push_check_state()
-			set(CMAKE_REQUIRED_LIBRARIES bcrypt)
-			check_symbol_exists(BCryptEncrypt windows.h BCRYPT_AVAILABLE)
-		cmake_pop_check_state()
+		try_compile(BCRYPT_AVAILABLE "${CMAKE_CURRENT_BINARY_DIR}/tryCompile" SOURCES "${CMAKE_CURRENT_LIST_DIR}/cmake/tryCompileTestBCrypt.cpp" OUTPUT_VARIABLE BCRYPT_AVAILABILITY_TEST_MESSAGES)
 		if (NOT BCRYPT_AVAILABLE)
+			message(STATUS ${BCRYPT_AVAILABILITY_TEST_MESSAGES})
 			message(FATAL_ERROR "You're on Windows but BCrypt seems to be unavailable, you will need OpenSSL")
 		endif()
 	endif()

--- a/cmake/tryCompileTestBCrypt.cpp
+++ b/cmake/tryCompileTestBCrypt.cpp
@@ -1,0 +1,9 @@
+#include <Windows.h>
+#include <bcrypt.h>
+#include <cstdio>
+#pragma comment(lib, "bcrypt.lib")
+
+int main(int, char **)
+{
+	printf("%p\n", &BCryptEncrypt);
+}


### PR DESCRIPTION
fixes: https://github.com/ValveSoftware/GameNetworkingSockets/issues/287

some explanation: it is possible there were mistakes in older versions of windows sdk, however, this does not manifest in your tests as you are using vcpkg, which actually forces selecting latest available sdk, however this was not the default until cmake 3.27.

either way, this version with try_compile works correctly without vcpkg even with the older windows sdk.

this PR also adds more tests, specifically for both OpenSSL and BCrypt on both windows 2019 and 2022.