### PR TITLE
Fix typo in steamnetworkingsockets_connections.cpp

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_connections.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_connections.cpp
@@ -1642,7 +1642,7 @@ ESteamNetConnectionEnd CSteamNetworkConnectionBase::FinishCryptoHandshake( bool 
 		return k_ESteamNetConnectionEnd_Remote_BadCrypt;
 	}
 
-	// Diffie–Hellman key exchange to get "premaster secret"
+	// Diffie-Â–Hellman key exchange to get "premaster secret"
 	AutoWipeFixedSizeBuffer<sizeof(SHA256Digest_t)> premasterSecret;
 	if ( !CCrypto::PerformKeyExchange( m_keyExchangePrivateKeyLocal, keyExchangePublicKeyRemote, &premasterSecret.m_buf ) )
 	{
@@ -2786,7 +2786,7 @@ bool CSteamNetworkConnectionBase::ReceivedMessage( CSteamNetworkingMessage *pMsg
 
 		// Add to the poll group, if we are in one
 		if ( m_pPollGroup )
-			pMsg->LinkToQueueTail( &CSteamNetworkingMessage::m_linksSecondaryQueue, &m_pPollGroup->m_queueRecvMessages );\
+			pMsg->LinkToQueueTail( &CSteamNetworkingMessage::m_linksSecondaryQueue, &m_pPollGroup->m_queueRecvMessages );
 
 		// Each if() branch has its own unlock, so we can spew in the branch above
 		g_lockAllRecvMessageQueues.unlock();


### PR DESCRIPTION
- Remove unnecessary backslash at the end of the code line
- Replace non-ascii hyphen with ascii hyphen