### PR TITLE
test_p2p : make the RunProcessInThread a daemon thread so we cleanly exit on error.

### DIFF
--- a/tests/test_p2p.py
+++ b/tests/test_p2p.py
@@ -19,6 +19,7 @@ class RunProcessInThread(threading.Thread):
 
     def __init__( self, tag, cmdline, env, **popen_kwargs ):
         threading.Thread.__init__( self, name=tag )
+        self.daemon = True
         self.tag = tag
         self.cmdline = cmdline
         if env:
@@ -63,6 +64,7 @@ class RunProcessInThread(threading.Thread):
         threading.Thread.join( self, timeout )
         if self.isAlive():
             self.WriteLn( "Still running after %d seconds.  Killing" % timeout )
+            global g_failed
             g_failed = True
             self.process.kill()
 


### PR DESCRIPTION
If the script calls `sys.exit(1)` on error, it would get stuck because the threads are not marked daemon and keep running (the trivial_signaling_server process).