### PR TITLE
fix: ack frame

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
@@ -1080,7 +1080,7 @@ bool CSteamNetworkConnectionBase::ProcessPlainTextDataChunk( int usecTimeSinceLa
 			{
 				static const char szAckLatestPktNum[] = "ack latest pktnum";
 				int64 nLowerBits, nMask;
-				if ( nFrameType & 0x40 )
+				if ( nFrameType & 0x10 )
 				{
 					READ_32BITU( nLowerBits, szAckLatestPktNum );
 					nMask = 0xffffffff;


### PR DESCRIPTION
There was a typo for checking against the size of `latest_received_pkt_num`.
As the packet mask is 0b10010000, `nFrameType & 0x40` will always be zero.   
I changed the mask to `0x10` according to the format [documentation](https://github.com/ValveSoftware/GameNetworkingSockets/blob/master/src/steamnetworkingsockets/clientlib/SNP_WIRE_FORMAT.md).
