### PR TITLE
fix: Integer Overflow or Wraparound on Multiplication result converted to larger type

### DIFF
--- a/src/tier1/utlmemory.cpp
+++ b/src/tier1/utlmemory.cpp
@@ -18,7 +18,7 @@ m_nAllocationCount( nInitAllocationCount ), m_nGrowSize( nGrowSize ), m_unSizeOf
 	if (m_nAllocationCount)
 	{
 		UTLMEMORY_TRACK_ALLOC();
-		m_pMemory = PvAlloc( m_nAllocationCount * m_unSizeOfElements );
+		m_pMemory = PvAlloc( static_cast<size_t>(m_nAllocationCount) * m_unSizeOfElements );
 	}
 }
 


### PR DESCRIPTION
## Ticket 🎟️ #363

fix the problem, we need to ensure that the multiplication is performed using a larger integer type to avoid overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done using the `size_t` type, which is typically larger than `unsigned int` and can hold larger values.

The specific change involves modifying the multiplication expression on line 21 to cast `m_nAllocationCount` to `size_t` before multiplying it by `m_unSizeOfElements`.

