### PR TITLE
Fix data type for config value SetString()

### DIFF
--- a/include/steam/steamnetworkingtypes.h
+++ b/include/steam/steamnetworkingtypes.h
@@ -1783,7 +1783,7 @@ struct SteamNetworkingConfigValue_t
 	inline void SetString( ESteamNetworkingConfigValue eVal, const char *data ) // WARNING - Just saves your pointer.  Does NOT make a copy of the string
 	{
 		m_eValue = eVal;
-		m_eDataType = k_ESteamNetworkingConfig_Ptr;
+		m_eDataType = k_ESteamNetworkingConfig_String;
 		m_val.m_string = data;
 	}
 };


### PR DESCRIPTION
I just tested this fix by editing `test_p2p.cpp` so that it uses non-global config instead.

Current code fails to set the option 103 (`k_ESteamNetworkingConfig_P2P_STUN_ServerList`):
```log
Running basic socket client/server test
peer_server> Executing: ./test_p2p --server --identity-local str:peer_server --identity-remote str:peer_client --signaling-server localhost:10000 --log peer_server.verbose.log
peer_client> Executing: ./test_p2p --client --identity-local str:peer_client --identity-remote str:peer_server --signaling-server localhost:10000 --log peer_client.verbose.log
peer_client>   0.006005 Initialized low level socket/threading support.
peer_server>   0.005724 Initialized low level socket/threading support.
peer_client>   0.011518 Connecting to 'str:peer_server', virtual port 0, from local virtual port 0.
peer_server>   0.011159 Creating listen socket, local virtual port 0
peer_client>   0.011533 Creating signaling session for peer 'str:peer_server'
peer_server>   0.011191 Cannot create listen socket.  Error setting option 103
peer_server> Assertion failed: g_hListenSock != k_HSteamListenSocket_Invalid, file ..\GameNetworkingSockets\tests\test_p2p.cpp, line 243
peer_client>   0.011629 Cannot create P2P connection to str:peer_server.  Error setting option 103
peer_client> Assertion failed: g_hConnection != k_HSteamNetConnection_Invalid, file ..\GameNetworkingSockets\tests\test_p2p.cpp, line 322
signaling> 2025/03/11 22:23:48 Listening at 0.0.0.0:10000
peer_client> Exitted with 3221226505
peer_server> Exitted with 3221226505
```

But with this fix, it reads the local config correctly:
```log
Running basic socket client/server test
peer_server> Executing: ./test_p2p --server --identity-local str:peer_server --identity-remote str:peer_client --signaling-server localhost:10000 --log peer_server.verbose.log
peer_client> Executing: ./test_p2p --client --identity-local str:peer_client --identity-remote str:peer_server --signaling-server localhost:10000 --log peer_client.verbose.log
signaling> 2025/03/11 22:26:12 Listening at 0.0.0.0:10000
peer_client>   0.029836 Initialized low level socket/threading support.
peer_server>   0.026900 Initialized low level socket/threading support.
peer_client>   0.035296 Connecting to 'str:peer_server', virtual port 0, from local virtual port 0.
peer_client>   0.035312 Creating signaling session for peer 'str:peer_server'
peer_server>   0.032442 Creating listen socket, local virtual port 0
signaling> 2025/03/11 22:26:12 [str:peer_server@[::1]:9809] Added connection
peer_client>   0.036716 [#1144459456 P2P str:peer_server vport 0] Relay candidates enabled by P2P_Transport_ICE_Enable, but P2P_TURN_ServerList is empty
peer_client>   0.045959 SteamNetworkingSockets lock held for 10.6ms.  (Performance warning.)  ConnectP2PCustomSignaling,Base::BInitConnection,GetIdentity,SetConfigValue,FinalizeLocalCrypto,CSteamNetworkConnectionP2P::CheckInitICE,CConnectionTransportP2PICE_Valve::Init
signaling> 2025/03/11 22:26:12 [str:peer_client@[::1]:9808] Added connection
peer_client> This is usually a symptom of a general performance problem such as thread starvation.
peer_client>   0.045977 Sending msg 'Greetings!'
```