### PR TITLE
Expose flat API for ISteamNetworkingMessages

### DIFF
--- a/include/steam/steamnetworkingsockets_flat.h
+++ b/include/steam/steamnetworkingsockets_flat.h
@@ -15,6 +15,7 @@
 #include "steamnetworkingtypes.h"
 #include "isteamnetworkingsockets.h"
 #include "isteamnetworkingutils.h"
+#include "isteamnetworkingmessages.h"
 class ISteamNetworkingConnectionSignaling;
 
 typedef uint64 uint64_steamid; // Used when passing or returning CSteamID
@@ -95,6 +96,15 @@ STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingUtils_SetConfigVa
 STEAMNETWORKINGSOCKETS_INTERFACE ESteamNetworkingGetConfigValueResult SteamAPI_ISteamNetworkingUtils_GetConfigValue( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigScope eScopeType, intptr_t scopeObj, ESteamNetworkingConfigDataType * pOutDataType, void * pResult, size_t * cbResult );
 STEAMNETWORKINGSOCKETS_INTERFACE const char * SteamAPI_ISteamNetworkingUtils_GetConfigValueInfo( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eValue, ESteamNetworkingConfigDataType * pOutDataType, ESteamNetworkingConfigScope * pOutScope );
 STEAMNETWORKINGSOCKETS_INTERFACE ESteamNetworkingConfigValue SteamAPI_ISteamNetworkingUtils_IterateGenericEditableConfigValues( ISteamNetworkingUtils* self, ESteamNetworkingConfigValue eCurrent, bool bEnumerateDevVars );
+
+// ISteamNetworkingMessages
+STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingMessages *SteamAPI_SteamNetworkingMessages_v002();
+STEAMNETWORKINGSOCKETS_INTERFACE EResult SteamAPI_ISteamNetworkingMessages_SendMessageToUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, const void * pubData, uint32 cubData, int nSendFlags, int nRemoteChannel );
+STEAMNETWORKINGSOCKETS_INTERFACE int SteamAPI_ISteamNetworkingMessages_ReceiveMessagesOnChannel( ISteamNetworkingMessages* self, int nLocalChannel, SteamNetworkingMessage_t ** ppOutMessages, int nMaxMessages );
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_AcceptSessionWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote );
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_CloseSessionWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote );
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_CloseChannelWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, int nLocalChannel );
+STEAMNETWORKINGSOCKETS_INTERFACE ESteamNetworkingConnectionState SteamAPI_ISteamNetworkingMessages_GetSessionConnectionInfo( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, SteamNetConnectionInfo_t * pConnectionInfo, SteamNetConnectionRealTimeStatus_t * pQuickStatus );
 
 // SteamNetworkingIPAddr
 STEAMNETWORKINGSOCKETS_INTERFACE void SteamAPI_SteamNetworkingIPAddr_Clear( SteamNetworkingIPAddr* self );

--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_flat.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_flat.cpp
@@ -315,6 +315,37 @@ STEAMNETWORKINGSOCKETS_INTERFACE ESteamNetworkingConfigValue SteamAPI_ISteamNetw
 	return self->IterateGenericEditableConfigValues( eCurrent,bEnumerateDevVars );
 }
 
+//--- ISteamNetworkingMessages-------------------------
+
+STEAMNETWORKINGSOCKETS_INTERFACE ISteamNetworkingMessages *SteamAPI_SteamNetworkingMessages_v002()
+{
+	return SteamNetworkingMessages();
+}
+STEAMNETWORKINGSOCKETS_INTERFACE EResult SteamAPI_ISteamNetworkingMessages_SendMessageToUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, const void * pubData, uint32 cubData, int nSendFlags, int nRemoteChannel )
+{
+	return self->SendMessageToUser( identityRemote,pubData,cubData,nSendFlags,nRemoteChannel );
+}
+STEAMNETWORKINGSOCKETS_INTERFACE int SteamAPI_ISteamNetworkingMessages_ReceiveMessagesOnChannel( ISteamNetworkingMessages* self, int nLocalChannel, SteamNetworkingMessage_t ** ppOutMessages, int nMaxMessages )
+{
+	return self->ReceiveMessagesOnChannel( nLocalChannel,ppOutMessages,nMaxMessages );
+}
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_AcceptSessionWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote )
+{
+	return self->AcceptSessionWithUser( identityRemote );
+}
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_CloseSessionWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote )
+{
+	return self->CloseSessionWithUser( identityRemote );
+}
+STEAMNETWORKINGSOCKETS_INTERFACE bool SteamAPI_ISteamNetworkingMessages_CloseChannelWithUser( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, int nLocalChannel )
+{
+	return self->CloseChannelWithUser( identityRemote,nLocalChannel );
+}
+STEAMNETWORKINGSOCKETS_INTERFACE ESteamNetworkingConnectionState SteamAPI_ISteamNetworkingMessages_GetSessionConnectionInfo( ISteamNetworkingMessages* self, const SteamNetworkingIdentity & identityRemote, SteamNetConnectionInfo_t * pConnectionInfo, SteamNetConnectionRealTimeStatus_t * pQuickStatus )
+{
+	return self->GetSessionConnectionInfo( identityRemote,pConnectionInfo,pQuickStatus );
+}
+
 //--- SteamNetworkingIPAddr-------------------------
 
 STEAMNETWORKINGSOCKETS_INTERFACE void SteamAPI_SteamNetworkingIPAddr_Clear( SteamNetworkingIPAddr* self )


### PR DESCRIPTION
I've tested calling these new flat APIs with a [test commit](https://github.com/nalchi-net/GnsSharp/blob/e976221515571c6fecdb6278490fe9d4d59bc7f8/GnsSharp/ISteamNetworkingMessages.cs#L58) in [my C# binding GnsSharp](https://github.com/nalchi-net/GnsSharp):
```cs
SteamNetworkingIPAddr addr = default;
addr.ParseString("127.0.0.1:43000");

SteamNetworkingIdentity ident = default;
ident.SetIPAddr(in addr);

ISteamNetworkingMessages.User!.SendMessageToUser(ident, data, ESteamNetworkingSendType.ReliableNoNagle, 0);
```

And the flat API is successfully called, at least:
```powershell
[Verbose] Messages session ip:127.0.0.1:43000: created
[Bug] Cannot use P2P connectivity.  CreateConnectionSignaling callback not set
[Bug] src\steamnetworkingsockets\clientlib\csteamnetworkingmessages.cpp(473): Failed to create connection to 'ip:127.0.0.1:43000' for new messages session
```