### PR TITLE
build: Compilation fixes for MinGW toolchain

### DIFF
--- a/include/steam/steamnetworkingtypes.h
+++ b/include/steam/steamnetworkingtypes.h
@@ -1893,7 +1893,7 @@ typedef SteamNetworkingMessage_t ISteamNetworkingMessage;
 typedef SteamNetworkingErrMsg SteamDatagramErrMsg;
 
 inline void SteamNetworkingIPAddr::Clear() { memset( this, 0, sizeof(*this) ); }
-inline bool SteamNetworkingIPAddr::IsIPv6AllZeros() const { const uint64 *q = (const uint64 *)m_ipv6; return q[0] == 0 && q[1] == 0; }
+inline bool SteamNetworkingIPAddr::IsIPv6AllZeros() const { uint64 q[2] = {}; memcpy(q, m_ipv6, sizeof(m_ipv6)); return q[0] == 0 && q[1] == 0; }
 inline void SteamNetworkingIPAddr::SetIPv6( const uint8 *ipv6, uint16 nPort ) { memcpy( m_ipv6, ipv6, 16 ); m_port = nPort; }
 inline void SteamNetworkingIPAddr::SetIPv4( uint32 nIP, uint16 nPort ) { m_ipv4.m_8zeros = 0; m_ipv4.m_0000 = 0; m_ipv4.m_ffff = 0xffff; m_ipv4.m_ip[0] = uint8(nIP>>24); m_ipv4.m_ip[1] = uint8(nIP>>16); m_ipv4.m_ip[2] = uint8(nIP>>8); m_ipv4.m_ip[3] = uint8(nIP); m_port = nPort; }
 inline bool SteamNetworkingIPAddr::IsIPv4() const { return m_ipv4.m_8zeros == 0 && m_ipv4.m_0000 == 0 && m_ipv4.m_ffff == 0xffff; }

--- a/src/public/tier0/valve_tracelogging.h
+++ b/src/public/tier0/valve_tracelogging.h
@@ -82,7 +82,13 @@
 	#include <windows.h>
 	//#include <ShlObj.h>
 	//#include <winsock2.h>
-	#include <winmeta.h>
+
+	// TraceLoggingProvider-related header files are not available in MinGW builds, so disable it.
+	#if defined(_WIN32) && (defined(__MINGW32__) || defined(__MINGW64__))
+		#define VALVE_DISABLE_TRACELOGGING
+	#else
+		#include <winmeta.h>
+	#endif
 
 	#ifdef VALVE_DISABLE_TRACELOGGING
 		#define IsTraceLoggingEnabled() false

--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
@@ -74,6 +74,15 @@ TRACELOGGING_DEFINE_PROVIDER(
 constexpr int k_cbETWEventUDPPacketDataSize = 16;
 #endif
 
+#if defined(_WIN32) && (defined(__MINGW32__) || defined(__MINGW64__))
+	// This one contains `_WSACMSGHDR` and friends in MinGW case (as opposed to `ws2def.h` for ordinary windows builds)
+	#include <mswsock.h>
+	#define cmsghdr WSACMSGHDR
+	#define CMSGHDR WSACMSGHDR
+	#define CMSG_FIRSTHDR WSA_CMSG_FIRSTHDR
+	#define CMSG_NXTHDR WSA_CMSG_NXTHDR
+#endif
+
 namespace SteamNetworkingSocketsLib {
 
 inline void ETW_LongOp( const char *opName, SteamNetworkingMicroseconds usec, const char *pszInfo )

--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_lowlevel.cpp
@@ -78,6 +78,7 @@ namespace SteamNetworkingSocketsLib {
 
 inline void ETW_LongOp( const char *opName, SteamNetworkingMicroseconds usec, const char *pszInfo )
 {
+#if IsTraceLoggingEnabled()
 	if ( !pszInfo )
 		pszInfo = "";
 	TraceLoggingWrite(
@@ -87,6 +88,11 @@ inline void ETW_LongOp( const char *opName, SteamNetworkingMicroseconds usec, co
 		TraceLoggingUInt64( usec, "Microseconds" ),
 		TraceLoggingString( pszInfo, "ExtraInfo" )
 	);
+#else
+	(void)opName;
+	(void)usec;
+	(void)pszInfo;
+#endif
 }
 
 constexpr int k_msMaxPollWait = 1000;
@@ -4513,6 +4519,7 @@ STEAMNETWORKINGSOCKETS_INTERFACE void SteamNetworkingSockets_DefaultPreFormatDeb
 	// Gah, some, but not all, of our code has newlines on the end
 	V_StripTrailingWhitespaceASCII( buf );
 
+#if IsTraceLoggingEnabled()
 	// Emit an ETW event.  Unfortunately, TraceLoggingLevel requires a constant argument
 	if ( IsTraceLoggingProviderEnabled( HTraceLogging_SteamNetworkingSockets ) )
 	{
@@ -4553,6 +4560,7 @@ STEAMNETWORKINGSOCKETS_INTERFACE void SteamNetworkingSockets_DefaultPreFormatDeb
 			);
 		}
 	}
+#endif // IsTraceLoggingEnabled()
 
 	// Spew to log file?
 	#ifdef STEAMNETWORKINGSOCKETS_ENABLE_SYSTEMSPEW


### PR DESCRIPTION
This changeset incorporates a few fixes for build errors and warnings found when building GNS via llvm-mingw toolchain:

* TraceLoggingProvider: Disable for MinGW builds (MinGW-provided winapi headers differ from original WinSDK headers a lot, which poses a problem when trying to compile TraceLoggingProvider code)
* build: Fix compilation errors for `cmsghdr`-related things in MinGW builds (MinGW requires to include a different header file + need to alias WSACMSGHDR* to CMSGHDR/cmsghdr to avoid compilation errors)
* SteamNetworkingIPAddr: fix potentially dangerous `-wcast-align` warning in `IsIPv6AllZeroes()`