### PR TITLE
fix(feat): Multiplication result converted to larger type

### DIFF
--- a/src/tier1/utlmemory.cpp
+++ b/src/tier1/utlmemory.cpp
@@ -18,7 +18,7 @@ m_nAllocationCount( nInitAllocationCount ), m_nGrowSize( nGrowSize ), m_unSizeOf
 	if (m_nAllocationCount)
 	{
 		UTLMEMORY_TRACK_ALLOC();
-		m_pMemory = PvAlloc( m_nAllocationCount * m_unSizeOfElements );
+		m_pMemory = PvAlloc( static_cast<size_t>(m_nAllocationCount) * m_unSizeOfElements );
 	}
 }
 


### PR DESCRIPTION
https://github.com/ValveSoftware/GameNetworkingSockets/blob/725e273c7442bac7a8bc903c0b210b1c15c34d92/src/tier1/utlmemory.cpp#L21-L21

fix the issue need to ensure that the multiplication is performed using a larger type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific change involves modifying line 21 to cast `m_nAllocationCount` or `m_unSizeOfElements` to `size_t` before the multiplication. This change is localized and does not affect the rest of the code's functionality.


The product performs a calculation that can produce an integer overflow or wraparound when the logic assumes that the resulting value will always be larger than the original value. This occurs when an integer value is incremented to a value that is too large to store in the associated representation. When this occurs, the value may become a very small or negative number.	


![CWE-190-Diagram](https://github.com/user-attachments/assets/1d1630e7-b3f8-42df-b972-d46176f38eac)


This rule finds code that converts the result of an integer multiplication to a larger type. Since the conversion applies after the multiplication, arithmetic overflow may still occur. The rule flags every multiplication of two non-constant integer expressions that is (explicitly or implicitly) converted to a larger integer type. The conversion is an indication that the expression would produce a result that would be too large to fit in the smaller integer type.


```cpp
int i = 2000000000;
long j = i * i; //Wrong: due to overflow on the multiplication between ints, 
                //will result to j being -1651507200, not 4000000000000000000

long k = (long) i * i; //Correct: the multiplication is done on longs instead of ints, 
                       //and will not overflow

long l = static_cast<long>(i) * i; //Correct: modern C++
```
## References
[Multiplicative Operators and the Modulus Operator](https://docs.microsoft.com/en-us/cpp/cpp/multiplicative-operators-and-the-modulus-operator)
[Integer overflow](http://www.cplusplus.com/articles/DE18T05o/)
[CWE-190](https://cwe.mitre.org/data/definitions/190.html)
[CWE-192](https://cwe.mitre.org/data/definitions/192.html)
[CWE-197](https://cwe.mitre.org/data/definitions/197.html)
[CWE-681](https://cwe.mitre.org/data/definitions/681.html)


![68747470733a2f2f692e6962622e636f2e636f6d2f5942625a773035712f59656c6c6f772d616e642d426c61636b2d436972636c65732d417274732d616e642d4372616674732d43726561746976652d4167656e63792d4c6f676f2e706e67](https://github.com/user-attachments/assets/fef2d41b-c349-42b1-aae8-f68586da453b)

