### PR TITLE
Fix CI build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
-        os-version: [2022, latest]
+        os-version: [2022, 2025]
         crypto: [OpenSSL, BCrypt]
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os-version: [2019, 2022]
+        # Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
+        os-version: [2022, latest]
         crypto: [OpenSSL, BCrypt]
     env:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg


### PR DESCRIPTION
replace Windows server 2019 with 2025 as 2019 is no longer supported on Github as a valid runner.

Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045