### PR TITLE
Security bypass in CheckCertPOPID

### DIFF
--- a/src/steamnetworkingsockets/steamnetworkingsockets_certstore.cpp
+++ b/src/steamnetworkingsockets/steamnetworkingsockets_certstore.cpp
@@ -775,7 +775,7 @@ bool CheckCertPOPID( const CMsgSteamDatagramCertificate &msgCert, const CertAuth
 		if ( !pCACertAuthScope || pCACertAuthScope->m_pops.HasItem( popID ) )
 			return true;
 		V_sprintf_safe( errMsg, "Cert is not restricted by POPID, but CA trust chain is, and does not authorize %s", SteamNetworkingPOPIDRender( popID ).c_str() );
-		return true;
+		return false;
 	}
 
 	// Search cert for the one they are trying


### PR DESCRIPTION
When the cert isn't tied to a POPID but the CA trust chain is restricted and does not authorize the requested POP, the function correctly formats an error message - then returns true anyway, granting access.

It shouldn't grant access, so the return value should be `false`.