### PR TITLE
AssignConfigValueTyped: int64-to-int32 conversion dereferences value as pointer

### DIFF
--- a/src/steamnetworkingsockets/clientlib/csteamnetworkingsockets.cpp
+++ b/src/steamnetworkingsockets/clientlib/csteamnetworkingsockets.cpp
@@ -1922,7 +1922,7 @@ static bool AssignConfigValueTyped( int32 *pVal, ESteamNetworkingConfigDataType 
 			int64 arg = *(int64*)pArg;
 			if ( (int32)arg != arg )
 				return false; // Cannot truncate!
-			*pVal = *(int32*)arg;
+			*pVal = (int32)arg;
 			break;
 		}
 


### PR DESCRIPTION
The `AssignConfigValueTyped(int32*, ...)` overload has a typo in the Int64 case that causes a crash.

**Affected code:**
```
int64 arg = *(int64*)pArg;
if ( (int32)arg != arg )
    return false;
*pVal = *(int32*)arg;  // 'arg' treated as a pointer instead of a value
```

**Fix:**
```
int64 arg = *(int64*)pArg;
if ( (int32)arg != arg )
    return false;
*pVal = (int32)arg;
```

The value of `arg` is incorrectly cast to a pointer and dereferenced, rather than being cast directly to `int32`. This will almost certainly cause a segfault or memory corruption at runtime whenever a config value of type `int32` is set by passing an `int64` argument.
