### PR TITLE
Swapped Identity Assignment in APICreateSocketPair

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_udp.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_udp.cpp
@@ -1870,8 +1870,8 @@ bool CSteamNetworkConnectionlocalhostLoopback::APICreateSocketPair( CSteamNetwor
 
 	SteamDatagramErrMsg errMsg;
 
-	pConn[1] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[0], scopeLock[0] );
-	pConn[0] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[1], scopeLock[1] );
+	pConn[0] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[0], scopeLock[0] );
+	pConn[1] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[1], scopeLock[1] );
 	if ( !pConn[0] || !pConn[1] )
 	{
 failed:


### PR DESCRIPTION
`pConn[0]` is initialized with `pIdentity[1]` and `scopeLock[1]`
`pConn[1]` is initialized with `pIdentity[0]` and `scopeLock[0]`

The indices are inverted. Each connection slot gets the wrong identity and the wrong scope lock.

Fix:
```
pConn[0] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[0], scopeLock[0] );
pConn[1] = new CSteamNetworkConnectionlocalhostLoopback( pSteamNetworkingSocketsInterface, pIdentity[1], scopeLock[1] );
```