### PR TITLE
Prevent std::map key mutation in packet gap handling

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_snp.cpp
@@ -1031,10 +1031,9 @@ bool CSteamNetworkConnectionBase::ProcessPlainTextDataChunk( int usecTimeSinceLa
 			{
 				if ( h->second.m_nEnd > m_receiverState.m_nMinPktNumToSendAcks )
 				{
-					// Ug.  You're not supposed to modify the key in a map.
-					// I suppose that's legit, since you could violate the ordering.
-					// but in this case I know that this change is OK.
-					const_cast<int64 &>( h->first ) = m_receiverState.m_nMinPktNumToSendAcks;
+					auto node = m_receiverState.m_mapPacketGaps.extract(h);
+    				node.key() = m_receiverState.m_nMinPktNumToSendAcks;
+    				m_receiverState.m_mapPacketGaps.insert(std::move(node));
 					break;
 				}
 


### PR DESCRIPTION
This PR fixes a **critical undefined behavior** bug in the Steam Networking Protocol implementation where a `std::map` key was being modified in-place using `const_cast`.

In `ProcessPlainTextDataChunk`, the code handling `stop_waiting` updates directly mutates the key of an element inside m_mapPacketGaps`. This violates the invariants of `std::map` (which relies on immutable keys for its internal tree structure), leading to undefined behavior, including potential data corruption, incorrect ordering, failed lookups, or crashes.

Issue in this line:
`const_cast<int64 &>( h->first ) = m_receiverState.m_nMinPktNumToSendAcks;`

And here's the fix:
```
auto node = m_receiverState.m_mapPacketGaps.extract(h);
node.key() = m_receiverState.m_nMinPktNumToSendAcks;
m_receiverState.m_mapPacketGaps.insert(std::move(node));
```

**Note: There's a subtle performance trade-off introduced:**
const_cast (old): O(1)
extract/insert (new): O(log n)