### PR TITLE
Fix stack-buffer-overflow in Windows thread-naming RaiseException (x64)

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_socketthread.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_socketthread.cpp
@@ -3402,7 +3402,7 @@ static void SteamNetworkingThreadProc()
 		}
 		__try
 		{
-			RaiseException( 0x406D1388, 0, sizeof(info)/sizeof(DWORD), (ULONG_PTR*)&info );
+			RaiseException( 0x406D1388, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info );
 		}
 		__except(EXCEPTION_CONTINUE_EXECUTION)
 		{


### PR DESCRIPTION
Fixes https://github.com/ValveSoftware/GameNetworkingSockets/issues/418

On x64, `sizeof(DWORD)` (4) != `sizeof(ULONG_PTR)` (8), so `sizeof(info)/sizeof(DWORD)` evaluates to 6, causing `RaiseException` to read 48 bytes from the 24-byte `THREADNAME_INFO` on the stack. 
MSVC AddressSanitizer correctly halts on this, so it is harmless at runtime (the extra bytes are valid stack, and `__except` swallows the exception), but it is an out-of-bounds read, so needed patching.

Change: used `sizeof(ULONG_PTR)` as the divisor, which is the form given in Microsoft's [own documentation](https://learn.microsoft.com/en-us/visualstudio/debugger/tips-for-debugging-threads?view=visualstudio&tabs=csharp#set-a-thread-name-by-throwing-an-exception) and produces the correct count on both x86 and x64.