### PR TITLE
Fix stale vcpkg manifest mode link

### DIFF
--- a/examples/vcpkg_example_chat/README.md
+++ b/examples/vcpkg_example_chat/README.md
@@ -15,7 +15,7 @@ you are pulling in vcpkg's cmake toolchain file.  Then all you need to do is:
 # Building the example project using vcpkg in manifest mode
 
 Here are some specific instructions that build the example project using vcpkg in
-["manifest mode"](https://vcpkg.readthedocs.io/en/latest/users/manifests/).
+["manifest mode"](https://learn.microsoft.com/en-us/vcpkg/concepts/manifest-mode).
 This example assumes Windows, and also it's recommended to run this from a
 Visual Studio command prompt so we know what compiler to use.
 


### PR DESCRIPTION
## Summary

The vcpkg example still links to the legacy ReadTheDocs page that was
replaced in `BUILDING.md` by #335. The old URL currently returns a
Cloudflare verification page with HTTP 429 instead of the documentation.

Update the example to use the same current Microsoft Learn manifest mode
page as `BUILDING.md`.

## Verification

- Confirmed the previous URL returns HTTP 429 and a Cloudflare challenge
- Confirmed the Microsoft Learn URL returns HTTP 200 without redirects
- Confirmed the replacement page documents manifest mode and `vcpkg.json`
- Confirmed no references to the previous URL remain
- `git diff --check`

Build not run because this changes only a documentation URL.