### PR TITLE
mingw build: alias CMSG_LEN like the other cmsg accessors

### DIFF
--- a/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_socketthread.cpp
+++ b/src/steamnetworkingsockets/clientlib/steamnetworkingsockets_socketthread.cpp
@@ -77,6 +77,7 @@ constexpr int k_cbETWEventUDPPacketDataSize = 16;
 	#define CMSGHDR WSACMSGHDR
 	#define CMSG_FIRSTHDR WSA_CMSG_FIRSTHDR
 	#define CMSG_NXTHDR WSA_CMSG_NXTHDR
+	#define CMSG_LEN WSA_CMSG_LEN
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
The MinGW compatibility block maps cmsghdr, CMSG_FIRSTHDR, and CMSG_NXTHDR (and, just below, CMSG_DATA) to their WSA_-prefixed forms, but not CMSG_LEN. MSVC builds work regardless because its ws2def.h happens to define the unprefixed CMSG_LEN; mingw-w64's headers only provide WSA_CMSG_LEN, so the IP_TOS / IPV6_TCLASS cmsg_len checks in the recvmsg path fail to compile:

    error: 'CMSG_LEN' was not declared in this scope

Alias it alongside the others.